### PR TITLE
eat: astro-font - optimize fonts & prevent CLS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "dependencies": {
         "@astrojs/check": "^0.3.1",
         "astro": "^4.0.3",
+        "astro-font": "^0.0.81",
         "typescript": "^5.2.2"
       },
       "devDependencies": {
+        "@types/node": "^20.12.12",
         "husky": "^8.0.3",
         "prettier": "^3.0.3",
         "prettier-plugin-astro": "^0.12.1"
@@ -1678,6 +1680,15 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
       "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
     },
+    "node_modules/@types/node": {
+      "version": "20.12.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
+      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
+      "devOptional": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
@@ -1980,6 +1991,11 @@
       "optionalDependencies": {
         "sharp": "^0.33.3"
       }
+    },
+    "node_modules/astro-font": {
+      "version": "0.0.81",
+      "resolved": "https://registry.npmjs.org/astro-font/-/astro-font-0.0.81.tgz",
+      "integrity": "sha512-VmK4kqzNpOAt2LASVbw2cbbe9sD6K30E7jOjqzHxHieHMTWInkdOljtzHmNGvKr3P0MeF4Wy+Z7j6CdETFecDA=="
     },
     "node_modules/axobject-query": {
       "version": "4.0.0",
@@ -5802,6 +5818,12 @@
       "dependencies": {
         "semver": "^7.3.8"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "devOptional": true
     },
     "node_modules/unherit": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,11 @@
   "dependencies": {
     "@astrojs/check": "^0.3.1",
     "astro": "^4.0.3",
+    "astro-font": "^0.0.81",
     "typescript": "^5.2.2"
   },
   "devDependencies": {
+    "@types/node": "^20.12.12",
     "husky": "^8.0.3",
     "prettier": "^3.0.3",
     "prettier-plugin-astro": "^0.12.1"

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,6 +2,8 @@
 import "@styles/reset.css";
 import "@styles/global.css";
 import "@styles/variables.css";
+import { join } from "node:path";
+import { AstroFont } from "astro-font";
 
 export interface Props {
   title: string;
@@ -50,6 +52,38 @@ const socialImageURL = new URL("/seo.png", Astro.url);
     <meta name="twitter:description" content={metaData.description} />
     <meta name="twitter:image" content={socialImageURL} />
     <meta name="twitter:image:alt" content={title} />
+    <AstroFont
+      config={[
+        {
+          name: "Anybody",
+          src: [
+            {
+              style: 'normal',
+              weight: '400',
+              path: join(process.cwd(), "public", "fonts", "anybody-v11-latin-regular.woff2")
+            },
+          ],
+          preload: false,
+          display: "swap",
+          fallback: "sans-serif",
+          cssVariable: "font-anybody",
+        },
+        {
+          name: "Inter",
+          src: [
+            {
+              style: 'normal',
+              weight: '400',
+              path: join(process.cwd(), "public", "fonts", "inter-v13-latin-regular.woff2")
+            },
+          ],
+          preload: false,
+          display: "swap",
+          fallback: "sans-serif",
+          cssVariable: "font-inter",
+        },
+      ]}
+    />
   </head>
   <body>
     <slot />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,21 +1,3 @@
-/* Typography */
-
-@font-face {
-  font-display: optional;
-  font-family: "Anybody";
-  font-style: normal;
-  font-weight: 400;
-  src: url("../fonts/anybody-v11-latin-regular.woff2") format("woff2");
-}
-
-@font-face {
-  font-display: optional;
-  font-family: "Inter";
-  font-style: normal;
-  font-weight: 400;
-  src: url("../fonts/inter-v13-latin-regular.woff2") format("woff2");
-}
-
 /* Focus behaviour */
 
 :is(a, button, input, textarea, summary) {
@@ -56,7 +38,7 @@ body {
 h1,
 h2 {
   color: var(--color-white);
-  font-family: "Anybody", sans-serif;
+  font-family: var(--font-anybody);
 }
 
 h1 {
@@ -70,7 +52,7 @@ a,
 blockquote,
 ul,
 p {
-  font-family: "Inter", sans-serif;
+  font-family: var(--font-inter);
   font-size: var(--step-1);
   hyphens: auto;
 }


### PR DESCRIPTION
Astro Font: https://www.launchfa.st/blog/building-astro-font

# Changes

This PR integrates `astro-font` which automatically generates the fallback font and pass it as CSS variables.